### PR TITLE
Modify gemspec and extconf.rb for easy building

### DIFF
--- a/bossan.gemspec
+++ b/bossan.gemspec
@@ -6,16 +6,6 @@ gem_files = Dir["LICENSE.txt",
                 "lib/**/*.rb",
                 "ext/**/*"]
  
- 
-if RbConfig::CONFIG['host_os'] =~ /linux/
-  gem_files.delete "ext/bossan/picoev_kqueue.c"
-elsif RbConfig::CONFIG['host_os'] =~ /darwin|(open|free)bsd/
-  gem_files.delete "ext/bossan/picoev_epoll.c"
-else
-  STDOUT.puts "Be posix compliant is mandatory"
-  exit 1
-end
- 
 Gem::Specification.new do |gem|
   gem.name = "bossan"
   gem.version = Bossan::VERSION

--- a/ext/bossan/extconf.rb
+++ b/ext/bossan/extconf.rb
@@ -10,4 +10,15 @@ Dir.chdir bossan_dir
 
 dir_config bossan_dir
 
+srcs = Dir.glob("*.c")
+if have_header("sys/epoll.h")
+  srcs.delete("picoev_kqueue.c")
+elsif have_header("sys/event.h")
+  srcs.delete("picoev_epoll.c")
+else
+  $stderr.puts "error: not found kqueue or epoll on your system."
+  exit 1
+end
+$srcs = srcs
+
 create_makefile "bossan/bossan_ext"


### PR DESCRIPTION
There is a problem `ruby extconf.rb && make` fail.
Fix it by move compiling file checks from gemspec to extconf.rb.
In extconf.rb, using not 'host_os' but have_header() method.
