### PR TITLE
In Rakefile, change system() to sh()

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,16 +5,16 @@ task :default => [:compile, :clean, :test]
 
 task :compile do
   Dir.chdir File.expand_path("../ext/bossan", __FILE__)
-  system "ruby extconf.rb"
-  system "make"
+  sh "ruby extconf.rb"
+  sh "make"
 end
 
 task :clean do
   Dir.chdir File.expand_path("../ext/bossan", __FILE__)
-  system "rm -f *.o Makefile"
+  sh "rm -f *.o Makefile"
 end
 
 task :test do
   Dir.chdir File.expand_path("../test", __FILE__)
-  system "ruby test_rack_spec.rb"
+  sh "ruby test_rack_spec.rb"
 end


### PR DESCRIPTION
When I saw Travis CI state, this job https://travis-ci.org/kubo39/bossan/jobs/5151300 looks failed, but state is passed.

Job log below:

> /home/travis/build/kubo39/bossan/lib/bossan.rb:2:in 'require_relative': no such file to load -- /home/travis/build/kubo39/bossan/lib/bossan/bossan_ext (LoadError)
>  from /home/travis/build/kubo39/bossan/lib/bossan.rb:2:in '<top (required)>'
>  from test_rack_spec.rb:2:in 'require'
>  from test_rack_spec.rb:2:in '<main>'
> 
>  The command "bundle exec rake" exited with 0.

This error occurs in `rake test,` `system "ruby test_rack_spec.rb"`. This command is failed, system() method returns status code 1, but rake is not handle it. (And rake returns status code 0, Travis CI worker thinks rake success, so state is set to passed.)

In this case, should use sh("command") method. sh("command") method is rake provided, rake aborted if command failed.
