### PR TITLE
Build failed in OSX (DLLIB file extension is .bundle)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require "rbconfig"
 
 task :default => [:compile, :clean, :test]
 
@@ -7,7 +8,7 @@ task :compile do
   Dir.chdir File.expand_path("../ext/bossan", __FILE__)
   sh "ruby extconf.rb"
   sh "make"
-  sh "mv bossan_ext.so ../../lib/bossan/"
+  sh "mv bossan_ext.#{RbConfig::CONFIG['DLEXT']} ../../lib/bossan/"
 end
 
 task :clean do


### PR DESCRIPTION
I tried to build, but rake aborted.

Logs:

```
$ rake
... complication logs ...
19 warnings generated.linking shared-object bossan/bossan_ext.bundle
mv bossan_ext.so ../../lib/bossan/
mv: rename bossan_ext.so to ../../lib/bossan/bossan_ext.so: No such file or directory
rake aborted!
Command failed with status (1): [mv bossan_ext.so ../../lib/bossan/...]
```

In OSX, the DLLIB file extension is ".bundle", not ".so".
We can check it using RbConfig::CONFIG['DLEXT'].
This patch fix it.
