### PR TITLE
Build failed in OSX (TCP_DEFER_ACCEPT)

### DIFF
--- a/ext/bossan/bossan_ext.c
+++ b/ext/bossan/bossan_ext.c
@@ -1533,8 +1533,10 @@ static void
 setup_listen_sock(int fd)
 {
   int on = 1, r = -1;
+#ifdef linux
   r = setsockopt(fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &on, sizeof(on));
   assert(r == 0);
+#endif
   r = fcntl(fd, F_SETFL, O_NONBLOCK);
   assert(r == 0);
 }


### PR DESCRIPTION
I tried to build, but rake aborted.

Logs:

```
 bossan_ext.c:1536:35: error: use of undeclared identifier 'TCP_DEFER_ACCEPT'
   r = setsockopt(fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &on, sizeof(on));
```

We can use TCP_DEFER_ACCEPT option only in Linux (2.4+).
This patch is quick-fix for not Linux Systems.
