### PR TITLE
Cannot rackup with -p option

### DIFF
--- a/lib/rack/handler/bossan.rb
+++ b/lib/rack/handler/bossan.rb
@@ -15,7 +15,7 @@ module Rack
         options = DEFAULT_OPTIONS.merge(options)
         puts "* Listening on tcp://#{options[:Host]}:#{options[:Port]}"
 
-        ::Bossan.listen(options[:Host], options[:Port])
+        ::Bossan.listen(options[:Host], options[:Port].to_i)
         ::Bossan.run(app)
       end
 

--- a/test/test_rack_handler.rb
+++ b/test/test_rack_handler.rb
@@ -1,0 +1,69 @@
+require_relative '../lib/rack/handler/bossan'
+require_relative './util'
+require 'minitest/unit'
+require 'test/unit/testcase'
+require 'uri'
+
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = "8000"
+ASSERT_RESPONSE = "Hello world!"
+RESPONSE = ["Hello ", "world!"].freeze
+
+
+class App
+  def call env
+    # p env
+    body = RESPONSE
+    [200,
+     {
+       'Content-type'=> 'text/plain',
+       'Content-length'=> RESPONSE.join.size.to_s
+     },
+     body
+    ]
+  end
+end
+
+
+class RackSpecTest < Test::Unit::TestCase
+
+  def test_get
+    response = Net::HTTP.start(DEFAULT_HOST, DEFAULT_PORT) {|http|
+      http.get("/")
+    }
+    assert_equal("200", response.code)
+    assert_equal(ASSERT_RESPONSE, response.body)
+  end
+
+  def test_post
+    response = Net::HTTP.post_form(URI.parse("http://#{DEFAULT_HOST}:#{DEFAULT_PORT}/"),
+                                   {'key1'=> 'value1', 'key2'=> 'value2'})
+    assert_equal("200", response.code)
+    assert_equal(ASSERT_RESPONSE, response.body)
+  end
+end
+
+
+begin
+  $stderr.puts RUBY_DESCRIPTION
+  pid = fork do
+    trap(:INT) { Rack::Handler::Bossan.stop }
+    Rack::Handler::Bossan.run(App.new, {
+                                :Host => DEFAULT_HOST, :Port => DEFAULT_PORT
+                              })
+  end
+
+  Process.detach pid
+
+  unless server_is_wake_up?
+    $stderr.puts "bossan won't wake up until you love it ..."
+    exit 1
+  end
+
+  err = MiniTest::Unit.new.run(ARGV)
+  exit false if err && err != 0
+
+ensure
+  Process.kill(:INT, pid)
+end


### PR DESCRIPTION
Cannot rackup with port option. 

Logs:

```
[nakano@iMac :~/prog/bossan/examples]$ rackup -s webrick -p 8000 -o localhost config.ru
[2013-07-27 23:52:26] INFO  WEBrick 1.3.1
[2013-07-27 23:52:26] INFO  ruby 1.9.3 (2012-04-20) [x86_64-darwin12.2.0]
[2013-07-27 23:52:26] INFO  WEBrick::HTTPServer#start: pid=7398 port=8000
^C[2013-07-27 23:52:29] INFO  going to shutdown ...
[2013-07-27 23:52:29] INFO  WEBrick::HTTPServer#start done.
[nakano@iMac :~/prog/bossan/examples]$ rackup -s bossan -p 8000 -o localhost config.ru
* Listening on tcp://localhost:8000
    /Users/nakano/Documents/program/bossan/lib/rack/handler/bossan.rb:18:in `listen': can't convert String into Integer (TypeError)
    from /Users/nakano/Documents/program/bossan/lib/rack/handler/bossan.rb:18:in `run'
    from /Users/nakano/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.5.2/lib/rack/server.rb:264:in `start'
    from /Users/nakano/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.5.2/lib/rack/server.rb:141:in `start'
    from /Users/nakano/.rvm/gems/ruby-1.9.3-p194/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
    from /Users/nakano/.rvm/gems/ruby-1.9.3-p194/bin/rackup:23:in `load'
    from /Users/nakano/.rvm/gems/ruby-1.9.3-p194/bin/rackup:23:in `<main>'
    from /Users/nakano/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/nakano/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `<main>'
[nakano@iMac :~/prog/bossan/examples]$
```

This error occurs at Rack::Handler::Bossan, so this handler expects :Port option is Numeric, but String.
This patch fix it, and add test for Rack::Handler::Bossan.

After this patch apply, Logs:

```
[nakano@iMac :~/prog/bossan/examples]$ rackup -s bossan -p 8000 -o localhost config.ru
* Listening on tcp://localhost:8000
^CBye.
[nakano@iMac :~/prog/bossan/examples]$ 
```
